### PR TITLE
cncli: Fix build for FreeBSD port using SODIUM_LIB_DIR

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,3 +1,5 @@
+use std::env;
+use std::path::Path;
 use std::process::Command;
 
 macro_rules! ok (($expression:expr) => ($expression.unwrap()));
@@ -8,24 +10,30 @@ macro_rules! log {
 }
 
 fn main() {
-    // Build and link IOHK libsodium
-    run("git", |command| {
-        command
-            .arg("submodule")
-            .arg("update")
-            .arg("--init")
-            .arg("--recursive")
-            .arg("--force")
-    });
-
-    // Build libsodium automatically (as part of rust build)
     #[cfg(not(feature = "libsodium-sys"))]
     {
-        let libsodium = autotools::Config::new("contrib/libsodium/").reconf("-vfi").build();
-        println!("cargo:rustc-link-search=native={}", libsodium.join("lib").display());
-        println!("cargo:rustc-link-lib=static=sodium");
+        // Use set libsodium env path
+        if env::var("SODIUM_LIB_DIR").is_ok() {
+            let libdir = env::var("SODIUM_LIB_DIR").unwrap();
+            println!("cargo:rustc-link-search=native={}", Path::new(&libdir).join("lib").display());
+            println!("cargo:rustc-link-lib=static=sodium");
+        } else {
+            // Build and link IOHK libsodium
+            run("git", |command| {
+                command
+                    .arg("submodule")
+                    .arg("update")
+                    .arg("--init")
+                    .arg("--recursive")
+                    .arg("--force")
+            });
+            // Build libsodium automatically (as part of rust build)
+            let libsodium = autotools::Config::new("contrib/libsodium/").reconf("-vfi").build();
+            println!("cargo:rustc-link-search=native={}", libsodium.join("lib").display());
+            println!("cargo:rustc-link-lib=static=sodium");
+        }
     }
-
+    
     // Link with libsodium system library
     #[cfg(feature = "libsodium-sys")]
     {

--- a/build.rs
+++ b/build.rs
@@ -15,7 +15,7 @@ fn main() {
         // Use set libsodium env path
         if env::var("SODIUM_LIB_DIR").is_ok() {
             let libdir = env::var("SODIUM_LIB_DIR").unwrap();
-            println!("cargo:rustc-link-search=native={}", Path::new(&libdir).join("lib").display());
+            println!("cargo:rustc-link-search=native={}", Path::new(&libdir).display());
             println!("cargo:rustc-link-lib=static=sodium");
         } else {
             // Build and link IOHK libsodium
@@ -33,7 +33,6 @@ fn main() {
             println!("cargo:rustc-link-lib=static=sodium");
         }
     }
-    
     // Link with libsodium system library
     #[cfg(feature = "libsodium-sys")]
     {


### PR DESCRIPTION
## Description
Modified build to work with FreeBSD port. Added ability to set SODIUM_LIB_DIR env variable to skip getting sodium from github.

## Where should the reviewer start?
Test build with libsodium not in system.

## Motivation and context
FreeBSD ports are unable to access the internet during the build process and use git commands. Due to the fact that the git command is always executed, build was failing.

I could have just made a patch... but decided that maybe it's best to add this feature upstream? Others might use this?

## How has this been tested?
Tested as part of the FreeBSD port build process using:
https://github.com/cardano-bsd-alliance/freebsd-ports-cncli/blob/main/Makefile