### PR TITLE
Add a systemd option for the leaderlog

### DIFF
--- a/scripts/cncli-leaderlog.sh
+++ b/scripts/cncli-leaderlog.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+#
+# Send slots to PoolTool, write slots.csv and mail leaderlog
+#
+# Depending on the day of the epoch we are in (1 to 5) this script will run one
+# or more of the tasks above.
+# On day 1: send slots for the current and previous epoch to PoolTool.
+# On day 4: calculate and mail next epoch leaderlog and write slots.csv.
+#
+# Usage:   Via systemd timer or ./cncli-leaderlog.sh
+# Author:  Leon • HAPPY Staking Pool
+#
+# Change the 'Pool specific variables' with values for your pool:
+#  - hexStakePool: The hexadecimal hash of your pool
+#  - jsonPoolTool: The config file to send slots to PoolTool (leave empty to skip).
+#  - slotsCsvFile: The CSV file to write assigned slots to (leave empty to skip).
+#  - mailLeaderLogsTo: The address to mail the leaderlog to (leave empty to skip).
+
+export CARDANO_NODE_SOCKET_PATH="/var/lib/cardano/mainnet/node.socket"
+
+# Pool specific variables
+timezone="Etc/UTC"
+hexStakePool=""
+jsonPoolTool="/usr/local/etc/pooltool.json"
+slotsCsvFile="/var/local/cncli/slots.csv"
+mailLeaderLogTo=""
+vrfSigningKeyFile="/etc/cardano/mainnet/keys/vrf.skey"
+shelleyGenesisFile="/etc/cardano/mainnet/shelley-genesis.json"
+byronGenesisFile="/etc/cardano/mainnet/byron-genesis.json"
+binCardanoCli="/usr/local/bin/cardano-cli"
+binCnCli="/usr/local/bin/cncli"
+dbCnCli="/var/local/cncli/db.sqlite"
+
+# Script internal variables
+secondsCardanoStart=$(date +%s -d "2017-09-23 21:44:51 +0000")
+daysCardanoStart=$(( secondsCardanoStart / 86400 ))
+secondsNow=$(date +%s)
+daysNow=$(( secondsNow / 86400 ))
+secondsSinceCardanoStart=$(( secondsNow - secondsCardanoStart ))
+daysSinceCardanoStart=$(( daysNow - daysCardanoStart ))
+secondsLeftInEpoch=$(( 432000 - (secondsSinceCardanoStart % 432000) ))
+dayOfEpoch=$(( daysSinceCardanoStart % 5 ))
+currentEpoch=$(( ( daysSinceCardanoStart - 1 ) / 5 ))
+
+set -o pipefail
+
+if [[ $dayOfEpoch -eq 0 ]]; then
+    echo "Today is the last day of epoch ${currentEpoch}"
+else
+    echo "Today is day ${dayOfEpoch} of epoch ${currentEpoch}"
+fi
+
+calculateLeaderLog ()
+{
+    if [[ -r "${vrfSigningKeyFile}" ]];
+    then
+        echo -n "Calculating leaderlog for $1 (${2}) epoch... "
+        poolSnapshot=$(nice -n 19 $binCardanoCli query stake-snapshot \
+            --stake-pool-id $hexStakePool --mainnet)
+        if [[ $? -eq 0 ]]; then echo "done"; else echo "failed!"; fi
+
+        poolTotalStake=$(echo "$poolSnapshot" | jq -r '.poolStakeMark')
+        poolActiveStake=$(echo "$poolSnapshot" | jq -r '.activeStakeMark')
+
+        $binCnCli leaderlog \
+            --db $dbCnCli --pool-id $hexStakePool --pool-vrf-skey $vrfSigningKeyFile \
+            --byron-genesis $byronGenesisFile --shelley-genesis $shelleyGenesisFile \
+            --pool-stake $poolTotalStake --active-stake $poolActiveStake \
+            --tz $timezone --ledger-set ${1} > /tmp/leaderlog
+
+    else
+        echo "The VRF signing key file is not readable."
+        exit 1
+    fi
+}
+
+mailLeaderLog ()
+{
+    if [[ `jq -r '.status' <<< "$(cat /tmp/leaderlog)"` == "ok" ]];
+    then
+        if [[ "${mailLeaderLogTo}" != "" ]];
+        then
+            echo -n "Mailing leaderlog to ${mailLeaderLogTo}... "
+            cat /tmp/leaderlog | jq | mail -s "Leaderlog for $1 epoch (${2})" -- $mailLeaderLogTo
+            if [[ $? -eq 0 ]]; then echo "done"; else echo "failed!"; fi
+        else
+            echo "Not mailing leaderlog"
+        fi
+    else
+        cat /tmp/leaderlog
+    fi
+}
+
+sendPoolToolSlots ()
+{
+    if [[ "${jsonPoolTool}" != "" && -r "${jsonPoolTool}" ]];
+    then
+        echo -n "Retrieving CNCLI database status... "
+        status=$(${binCnCli} status --db ${dbCnCli} --byron-genesis ${byronGenesisFile} \
+            --shelley-genesis ${shelleyGenesisFile} | jq -r '.status' )
+        if [[ "${status}" == "error" ]]; then echo "failed!"; echo "${status}"; else echo "done"; fi
+
+        if [[ "${status}" == "ok" ]];
+        then
+            echo -n "Sending slots to PoolTool... "
+            result=$(${binCnCli} sendslots --db ${dbCnCli} --byron-genesis ${byronGenesisFile} \
+                --shelley-genesis ${shelleyGenesisFile} --config ${jsonPoolTool})
+            if [[ "${result}" == "error" ]]; then echo "failed!"; echo "${result}"; else echo "done"; fi
+        fi
+    else
+        echo "Not sending slots to PoolTool"
+    fi
+}
+
+writeLeaderSlots ()
+{
+    if [[ "${slotsCsvFile}" != "" && -w `dirname "${slotsCsvFile}"` ]];
+    then
+        echo -n "Writing leaderlog to ${slotsCsvFile}... "
+        echo /tmp/leaderlog | jq -r '.assignedSlots[] | (.at|tostring) + "," + (.slot|tostring) + "," + (.no|tostring)' > $slotsCsvFile
+        if [[ $? -eq 0 ]]; then echo "done"; else echo "failed!"; fi
+    else
+        echo "Not writing slots.csv"
+    fi
+}
+
+if [[ $dayOfEpoch -eq 1 ]];
+then
+    calculateLeaderLog prev $(($currentEpoch-1))
+    calculateLeaderLog current $currentEpoch
+    sendPoolToolSlots
+fi
+
+if [[ $dayOfEpoch -eq 4 && $secondsLeftInEpoch -le 129600 && $secondsLeftInEpoch -gt 84600 ]];
+then
+    calculateLeaderLog next $(($currentEpoch+1))
+    mailLeaderLog next $(($currentEpoch+1))
+    writeLeaderSlots
+fi

--- a/scripts/cncli-leaderlog.sh
+++ b/scripts/cncli-leaderlog.sh
@@ -83,18 +83,13 @@ calculateLeaderLog ()
 
 mailLeaderLog ()
 {
-    if [[ `jq -r '.status' <<< "$(cat /tmp/leaderlog)"` == "ok" ]];
+    if [[ "${mailLeaderLogTo}" != "" && -r "/tmp/leaderlog" ]];
     then
-        if [[ "${mailLeaderLogTo}" != "" ]];
-        then
-            echo -n "Mailing leaderlog to ${mailLeaderLogTo}... "
-            cat /tmp/leaderlog | jq | mail -s "Leaderlog for $1 epoch (${2})" -- $mailLeaderLogTo
-            if [[ $? -eq 0 ]]; then echo "done"; else echo "failed!"; fi
-        else
-            echo "Not mailing leaderlog"
-        fi
+        echo -n "Mailing leaderlog to ${mailLeaderLogTo}... "
+        cat /tmp/leaderlog | jq | mail -s "Leaderlog for $1 epoch (${2})" -- $mailLeaderLogTo
+        if [[ $? -eq 0 ]]; then echo "done"; else echo "failed!"; fi
     else
-        cat /tmp/leaderlog
+        echo "Not mailing leaderlog"
     fi
 }
 
@@ -121,10 +116,10 @@ sendPoolToolSlots ()
 
 writeLeaderSlots ()
 {
-    if [[ "${slotsCsvFile}" != "" && -w `dirname "${slotsCsvFile}"` ]];
+    if [[ "${slotsCsvFile}" != "" && -w `dirname "${slotsCsvFile}"` && `jq -r '.status' <<< "$(cat /tmp/leaderlog)"` == "ok" ]];
     then
         echo -n "Writing leaderlog to ${slotsCsvFile}... "
-        echo /tmp/leaderlog | jq -r '.assignedSlots[] | (.at|tostring) + "," + (.slot|tostring) + "," + (.no|tostring)' > $slotsCsvFile
+        cat /tmp/leaderlog | jq -r '.assignedSlots[] | (.at|tostring) + "," + (.slot|tostring) + "," + (.no|tostring)' > $slotsCsvFile
         if [[ $? -eq 0 ]]; then echo "done"; else echo "failed!"; fi
     else
         echo "Not writing slots.csv"


### PR DESCRIPTION
The script will figure out where in the epoch we are and if the leaderlog for the next epoch is available or not. It should be activated by a systemd timer daily at 09:45 UTC (instructions in INSTALL.md), but it can be run manually at any time as well.

The script can be configured to do all or any of the following tasks:
 - Send prev and current slots to PoolTool on day 1 of the epoch
 - Mail the leaderlog for the next epoch on day 4 of the epoch
 - Write a slots.csv file on day 4 of the epoch

## Description
Add cncli-leaderlog.sh in the scripts/ directory.

## Where should the reviewer start?
Open the script and set the environment variables, then run the script manually on day 1 and 4 of the epoch or install the systemd timers (see updated INSTALL.md).

## Motivation and context
I prefer not to use cron and also I prefer to have all these small tasks handled by 1 script in 1 unit file/timer for easy setup and maintenance.

## Which issue it fixes?
<!--- Link to issue: Closes #issue-number -->

## How has this been tested?
Ran the script throughout several epochs.
