### PR TITLE
Updated scripts, so they will work with 8.0.0 and previous versions

### DIFF
--- a/scripts/cncli-leaderlog-current.sh
+++ b/scripts/cncli-leaderlog-current.sh
@@ -4,8 +4,15 @@ export CARDANO_NODE_SOCKET_PATH=/home/westbam/haskell/local/db/socket
 echo "BCSH"
 SNAPSHOT=$(/home/westbam/.local/bin/cardano-cli query stake-snapshot --stake-pool-id 00beef0a9be2f6d897ed24a613cf547bb20cd282a04edfc53d477114 --mainnet)
 /home/westbam/.cargo/bin/cncli sync --host 127.0.0.1 --port 6000 --no-service
-POOL_STAKE=$(echo "$SNAPSHOT" | grep -oP '(?<=    "poolStakeSet": )\d+(?=,?)')
-ACTIVE_STAKE=$(echo "$SNAPSHOT" | grep -oP '(?<=    "activeStakeSet": )\d+(?=,?)')
+echo $SNAPSHOT | grep -q "pools"
+if [ $? -eq 0 ]; then
+        STAKES=$(echo "$SNAPSHOT" | grep -oP '(?<=    "stakeSet": )\d+(?=,?)')
+        POOL_STAKE=$(echo $STAKES | cut -d' ' -f1)
+        ACTIVE_STAKE=$(echo $STAKES | cut -d' ' -f2)
+else
+        POOL_STAKE=$(echo "$SNAPSHOT" | grep -oP '(?<=    "poolStakeSet": )\d+(?=,?)')
+        ACTIVE_STAKE=$(echo "$SNAPSHOT" | grep -oP '(?<=    "activeStakeSet": )\d+(?=,?)')
+fi
 BCSH=`/home/westbam/.cargo/bin/cncli leaderlog --pool-id 00beef0a9be2f6d897ed24a613cf547bb20cd282a04edfc53d477114 --pool-vrf-skey ./bcsh.vrf.skey --byron-genesis /home/westbam/haskell/local/byron-genesis.json --shelley-genesis /home/westbam/haskell/local/shelley-genesis.json --pool-stake $POOL_STAKE --active-stake $ACTIVE_STAKE --consensus tpraos --ledger-set current`
 echo $BCSH | jq .
 

--- a/scripts/cncli-leaderlog-next.sh
+++ b/scripts/cncli-leaderlog-next.sh
@@ -4,8 +4,15 @@ export CARDANO_NODE_SOCKET_PATH=/home/westbam/haskell/local/db/socket
 echo "BCSH"
 SNAPSHOT=$(/home/westbam/.local/bin/cardano-cli query stake-snapshot --stake-pool-id 00beef0a9be2f6d897ed24a613cf547bb20cd282a04edfc53d477114 --mainnet)
 /home/westbam/.cargo/bin/cncli sync --host 127.0.0.1 --port 6000 --no-service
-POOL_STAKE=$(echo "$SNAPSHOT" | grep -oP '(?<=    "poolStakeMark": )\d+(?=,?)')
-ACTIVE_STAKE=$(echo "$SNAPSHOT" | grep -oP '(?<=    "activeStakeMark": )\d+(?=,?)')
+echo $SNAPSHOT | grep -q "pools"
+if [ $? -eq 0 ]; then
+	STAKES=$(echo "$SNAPSHOT" | grep -oP '(?<=    "stakeMark": )\d+(?=,?)')
+	POOL_STAKE=$(echo $STAKES | cut -d' ' -f1)
+	ACTIVE_STAKE=$(echo $STAKES | cut -d' ' -f2)
+else
+	POOL_STAKE=$(echo "$SNAPSHOT" | grep -oP '(?<=    "poolStakeMark": )\d+(?=,?)')
+	ACTIVE_STAKE=$(echo "$SNAPSHOT" | grep -oP '(?<=    "activeStakeMark": )\d+(?=,?)')
+fi
 BCSH=`/home/westbam/.cargo/bin/cncli leaderlog --pool-id 00beef0a9be2f6d897ed24a613cf547bb20cd282a04edfc53d477114 --pool-vrf-skey ./bcsh.vrf.skey --byron-genesis /home/westbam/haskell/local/byron-genesis.json --shelley-genesis /home/westbam/haskell/local/shelley-genesis.json --pool-stake $POOL_STAKE --active-stake $ACTIVE_STAKE --consensus tpraos --ledger-set next`
 echo $BCSH | jq .
 

--- a/scripts/cncli-leaderlog-prev.sh
+++ b/scripts/cncli-leaderlog-prev.sh
@@ -4,8 +4,15 @@ export CARDANO_NODE_SOCKET_PATH=/home/westbam/haskell/local/db/socket
 echo "BCSH"
 SNAPSHOT=$(/home/westbam/.local/bin/cardano-cli query stake-snapshot --stake-pool-id 00beef0a9be2f6d897ed24a613cf547bb20cd282a04edfc53d477114 --mainnet)
 /home/westbam/.cargo/bin/cncli sync --host 127.0.0.1 --port 6000 --no-service
-POOL_STAKE=$(echo "$SNAPSHOT" | grep -oP '(?<=    "poolStakeGo": )\d+(?=,?)')
-ACTIVE_STAKE=$(echo "$SNAPSHOT" | grep -oP '(?<=    "activeStakeGo": )\d+(?=,?)')
+echo $SNAPSHOT | grep -q "pools"
+if [ $? -eq 0 ]; then
+        STAKES=$(echo "$SNAPSHOT" | grep -oP '(?<=    "stakeGo": )\d+(?=,?)')
+        POOL_STAKE=$(echo $STAKES | cut -d' ' -f1)
+        ACTIVE_STAKE=$(echo $STAKES | cut -d' ' -f2)
+else
+        POOL_STAKE=$(echo "$SNAPSHOT" | grep -oP '(?<=    "poolStakeGo": )\d+(?=,?)')
+        ACTIVE_STAKE=$(echo "$SNAPSHOT" | grep -oP '(?<=    "activeStakeGo": )\d+(?=,?)')
+fi
 BCSH=`/home/westbam/.cargo/bin/cncli leaderlog --pool-id 00beef0a9be2f6d897ed24a613cf547bb20cd282a04edfc53d477114 --pool-vrf-skey ./bcsh.vrf.skey --byron-genesis /home/westbam/haskell/local/byron-genesis.json --shelley-genesis /home/westbam/haskell/local/shelley-genesis.json --pool-stake $POOL_STAKE --active-stake $ACTIVE_STAKE --consensus tpraos --ledger-set prev`
 echo $BCSH | jq .
 


### PR DESCRIPTION
## Description
I updated the cncli-leaderlog-*.sh scripts so they will work with 8.0.0 and earlier versions.

## Where should the reviewer start?
Try running the cncli-leaderlog-*.sh scripts with versions 8.0.0 and 1.35.7 of the Cardano node.

## Motivation and context
Currently, with the 8.0.0 version of Cardano Node, the cncli-leaderlog-*.sh scripts will not work.

## Which issue it fixes?

## How has this been tested?
I tested updated scripts on pre-prod with versions 1.35.7 and 8.0.0 of the Cardano node and got the same results as expected.
