### PR TITLE
Fix prev epoch argument and node 1.35 jq filters

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -243,9 +243,9 @@ CNCLI ```sync```, ```sendtip``` and ```leaderlog``` can be easily enabled as ```
 
 - ```sync``` will continuously keep the ```cncli.db``` database synchronized.
 - ```sendtip``` will continuously send your stake pool ```tip``` to PoolTool.
-- ```leaderlog``` will run every day at 09:45 UTC and can be configured to run all or any of the following tasks:
-  - on day 1 of the epoch send the assigned slots for the current and previous epoch to PoolTool and
-  - on day 4 of the epoch calculate the leaderlog for the next epoch and mail it and/or write a slots.csv file.
+- ```leaderlog``` will run twice per day and can be configured to run all or any of the following tasks:
+  - on beginning of the epoch send the assigned slots for the current and previous epoch to PoolTool and
+  - on day 4 of the epoch calculate the leaderlog for the next epoch, mail it and/or write a slots.csv file.
 
 To set up ```systemd```:
 
@@ -316,7 +316,7 @@ WantedBy=multi-user.target
 Description=CNCLI Leaderlog
 
 [Timer]
-OnCalendar=*-*-* 09:45:00 UTC
+OnCalendar=*-*-* 09,21:50:00 UTC
 Unit=cncli-leaderlog.service
 
 [Install]

--- a/scripts/cncli-leaderlog.sh
+++ b/scripts/cncli-leaderlog.sh
@@ -29,6 +29,7 @@ shelleyGenesisFile="/etc/cardano/mainnet/shelley-genesis.json"
 byronGenesisFile="/etc/cardano/mainnet/byron-genesis.json"
 binCardanoCli="/usr/local/bin/cardano-cli"
 binCnCli="/usr/local/bin/cncli"
+binPython3="/usr/bin/python3"
 dbCnCli="/var/local/cncli/db.sqlite"
 
 # Script internal variables
@@ -62,11 +63,11 @@ calculateLeaderLog ()
 
         if [[ $binCardanoCliMajorVersion -eq 1 ]];
         then
-            poolTotalStake=$(echo "$poolSnapshot" | jq -r .pool${3^})
-            poolActiveStake=$(echo "$poolSnapshot" | jq -r .active${3^})
+            poolTotalStake=$(echo "$poolSnapshot" | $binPython3 -c "import sys, json; print(json.load(sys.stdin)['pool${3^}'])")
+            poolActiveStake=$(echo "$poolSnapshot" | $binPython3 -c "import sys, json; print(json.load(sys.stdin)['active${3^}'])")
         else
-            poolTotalStake=$(echo "$poolSnapshot" | jq -r .pools.${hexStakePool}.$3)
-            poolActiveStake=$(echo "$poolSnapshot" | jq -r .total.$3)
+            poolTotalStake=$(echo "$poolSnapshot" | $binPython3 -c "import sys, json; print(json.load(sys.stdin)['pools']['${hexStakePool}']['${3}'])")
+            poolActiveStake=$(echo "$poolSnapshot" | $binPython3 -c "import sys, json; print(json.load(sys.stdin)['total']['$3'])")
         fi
 
         $binCnCli leaderlog \
@@ -74,7 +75,6 @@ calculateLeaderLog ()
             --byron-genesis $byronGenesisFile --shelley-genesis $shelleyGenesisFile \
             --pool-stake $poolTotalStake --active-stake $poolActiveStake \
             --tz $timezone --ledger-set ${1} > /tmp/leaderlog
-
     else
         echo "The VRF signing key file is not readable."
         exit 1

--- a/scripts/cncli-leaderlog.sh
+++ b/scripts/cncli-leaderlog.sh
@@ -4,8 +4,8 @@
 #
 # Depending on the day of the epoch we are in (1 to 5) this script will run one
 # or more of the tasks above.
-# On day 1: send slots for the current and previous epoch to PoolTool.
-# On day 4: calculate and mail next epoch leaderlog and write slots.csv.
+# On epoch start: send slots for the current and previous epoch to PoolTool.
+# On epoch day 4: calculate next epoch leaderlog, mail it and/or write slots.csv.
 #
 # Usage:   Via systemd timer or ./cncli-leaderlog.sh
 # Author:  Leon • HAPPY Staking Pool
@@ -126,14 +126,16 @@ writeLeaderSlots ()
     fi
 }
 
-if [[ $dayOfEpoch -eq 1 ]];
+# Run within 10 minutes of epoch start
+if [[ $dayOfEpoch -eq 0 && $secondsLeftInEpoch -lt 432000 && $secondsLeftInEpoch -gt 431400 ]];
 then
     calculateLeaderLog prev $(($currentEpoch-1)) stakeGo
     calculateLeaderLog current $currentEpoch stakeSet
     sendPoolToolSlots
 fi
 
-if [[ $dayOfEpoch -eq 4 && $secondsLeftInEpoch -le 129600 && $secondsLeftInEpoch -gt 84600 ]];
+# Run as soon as the leaderlog is available
+if [[ $dayOfEpoch -eq 4 && $secondsLeftInEpoch -le 129600 && $secondsLeftInEpoch -gt 129000 ]];
 then
     calculateLeaderLog next $(($currentEpoch+1)) stakeMark
     mailLeaderLog next $(($currentEpoch+1))

--- a/scripts/cncli-leaderlog.sh
+++ b/scripts/cncli-leaderlog.sh
@@ -63,11 +63,12 @@ calculateLeaderLog ()
 
         if [[ $binCardanoCliMajorVersion -eq 1 ]];
         then
-            poolTotalStake=$(echo "$poolSnapshot" | $binPython3 -c "import sys, json; print(json.load(sys.stdin)['pool${3^}'])")
-            poolActiveStake=$(echo "$poolSnapshot" | $binPython3 -c "import sys, json; print(json.load(sys.stdin)['active${3^}'])")
+            poolTotalStake=$(echo "$poolSnapshot" | grep -oP "(?<=    \"pool${3^}\": )\d+(?=,?)")
+            poolActiveStake=$(echo "$poolSnapshot" | grep -oP "(?<=    \"active${3^}\": )\d+(?=,?)")
         else
-            poolTotalStake=$(echo "$poolSnapshot" | $binPython3 -c "import sys, json; print(json.load(sys.stdin)['pools']['${hexStakePool}']['${3}'])")
-            poolActiveStake=$(echo "$poolSnapshot" | $binPython3 -c "import sys, json; print(json.load(sys.stdin)['total']['$3'])")
+            stakeNumbers=$(echo "$poolSnapshot" | grep -oP "(?<=    \"$3\": )\d+(?=,?)")
+            poolTotalStake=$(echo $stakeNumbers | cut -d' ' -f1)
+            poolActiveStake=$(echo $stakeNumbers | cut -d' ' -f2)
         fi
 
         $binCnCli leaderlog \

--- a/scripts/cncli-leaderlog.sh
+++ b/scripts/cncli-leaderlog.sh
@@ -62,8 +62,8 @@ calculateLeaderLog ()
 
         if [[ $binCardanoCliMajorVersion -eq 1 ]];
         then
-            poolTotalStake=$(echo "$poolSnapshot" | jq -r .poolStakeMark)
-            poolActiveStake=$(echo "$poolSnapshot" | jq -r .activeStakeMark)
+            poolTotalStake=$(echo "$poolSnapshot" | jq -r .pool${3^})
+            poolActiveStake=$(echo "$poolSnapshot" | jq -r .active${3^})
         else
             poolTotalStake=$(echo "$poolSnapshot" | jq -r .pools.${hexStakePool}.$3)
             poolActiveStake=$(echo "$poolSnapshot" | jq -r .total.$3)
@@ -128,7 +128,7 @@ writeLeaderSlots ()
 
 if [[ $dayOfEpoch -eq 1 ]];
 then
-    calculateLeaderLog prev $(($currentEpoch-1)) stakeSet
+    calculateLeaderLog prev $(($currentEpoch-1)) stakeGo
     calculateLeaderLog current $currentEpoch stakeSet
     sendPoolToolSlots
 fi


### PR DESCRIPTION
## Description
Now calculating the previous epoch with the correct 'stakeGo' parameter.
Now also using 'poolStakeSet' and 'poolStakeGo' for epoch calculations with node 1.35.x versions.

## Where should the reviewer start?
Run the script of day 1 and 4 of the epoch.
